### PR TITLE
Fix notify IV0 not working

### DIFF
--- a/static/js/map/map.pokemon.js
+++ b/static/js/map/map.pokemon.js
@@ -478,7 +478,7 @@ function isNotifPokemon(pokemon) {
     }
 
     if (settings.showPokemonValues) {
-        if (pokemon.individual_attack && settings.pokemonValuesNotifs && settings.notifValuesPokemon.has(pokemon.pokemon_id)) {
+        if (pokemon.weight && settings.pokemonValuesNotifs && settings.notifValuesPokemon.has(pokemon.pokemon_id)) {
             const ivsPercentage = getIvsPercentage(pokemon.individual_attack, pokemon.individual_defense, pokemon.individual_stamina)
             const level = getPokemonLevel(pokemon.cp_multiplier)
             if ((ivsPercentage >= settings.minNotifIvs || (settings.zeroIvsPokemonNotifs && ivsPercentage === 0)) &&


### PR DESCRIPTION
pokemon.individual_attack is not good test for verify if information IV is present. 
is 0 in 1/16 case and allways for IV0 .  Check weight is define is better

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
